### PR TITLE
Repeat markers for end and start are not supported #54

### DIFF
--- a/src/guido/xmlpart2guido.cpp
+++ b/src/guido/xmlpart2guido.cpp
@@ -382,15 +382,17 @@ void xmlpart2guido::checkOctavaEnd() {
         }else if (fCurrentScorePosition.toFloat() != 0.0) {
             // Create a HIDDEN Bar in case of fPendingBar equal to false.
             // This is the case for "bar-style" equal to "none" or "implicit" measures
-            Sguidoelement tag = guidotag::create("bar");
-            stringstream parameters;
-            std::string measNum = elt->getAttributeValue("number");
-            if (!measNum.empty()) {
-                parameters << "measNum="<< measNum<<", ";
+            if(!fInhibitNextBar){
+                Sguidoelement tag = guidotag::create("bar");
+                stringstream parameters;
+                std::string measNum = elt->getAttributeValue("number");
+                if (!measNum.empty()) {
+                    parameters << "measNum="<< measNum<<", ";
+                }
+                parameters << "hidden=\"true\"";
+                tag->add(guidoparam::create(parameters.str(), false));
+                add(tag);
             }
-            parameters << "hidden=\"true\"";
-            tag->add(guidoparam::create(parameters.str(), false));
-            add(tag);
         }
 
         fCurrentMeasureLength.set  (0, 1);

--- a/src/guido/xmlpart2guido.cpp
+++ b/src/guido/xmlpart2guido.cpp
@@ -1195,6 +1195,8 @@ std::string xmlpart2guido::parseMetronome ( metronomevisitor &mv )
             fCurrentOctavaShift = type;
         }else { // stop
             fShouldStopOctava = true;
+            //  Here the octave offset should take effect immediately, not the next time it is created
+            fCurrentOctavaShift = 0;
             tag->add (guidoparam::create(0, false));
         }
         


### PR DESCRIPTION
fix:Repeat markers for end and start are not supported , see if it is reasonable #54