### PR TITLE
fix ties in chords

### DIFF
--- a/src/visitors/midicontextvisitor.h
+++ b/src/visitors/midicontextvisitor.h
@@ -153,7 +153,7 @@ class EXP midicontextvisitor :
  		long		fDivisions;			// current division
         long		fCurrentDate;		// current date
         long		fLastPosition;		// last time position (used for chord)
-		long		fPendingDuration;	// pending duration (used for tied notes)
+		std::map<int, long> fPendingDurations;  // map of pitch -> pending duration,(used for tied notes)
         long		fCurrentDynamics;	// current dynamics ie MIDI velocity
         long		fTranspose;			// current transpose value
 		long		fTPQ;				// ticks-per-quater value for date conversion


### PR DESCRIPTION
This pull request fixes an issue where ties in chords are not handled correctly. I have included a MusicXML file that demonstrates the problem, in the tied notes in measure 17 and following.

The issue is that the current code accumulates the duration in fPendingDuration, but then assigns all the pending duration to the first stop note in the chord. The other notes in the last chord are not assigned any duration, causing the midi creation to go haywire.

The implemented fix in the PR is to administrate the pending duration for each pitch individually, using a map of pitch -> duration.

I have run the validations, and there are no changes in the validation files.

[comptine.xml.zip](https://github.com/user-attachments/files/17490517/comptine.xml.zip)
